### PR TITLE
fix: use valid JS syntax in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,3 +4,4 @@ const nextConfig = {
 };
 
 module.exports = nextConfig;
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   /* config options here */
 };
 
-export default nextConfig;
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- rewrite `next.config.js` to CommonJS format

## Testing
- `npx next lint` *(fails: lots of unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_684716964d848328a981b1b183fb9113